### PR TITLE
Use webrtcvad-wheels on all platforms

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 History
 =======
 
+Unreleased
+----------
+* Use webrtcvad-wheels on all platforms and remove the runtime setuptools dependency;
+
 0.4.31 (2025-11-23)
 -------------------
 * Add support for Python 3.14;

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,7 @@ numpy>=1.12.0
 pysubs2;python_version<'3.7'
 pysubs2>=1.2.0;python_version>='3.7'
 rich
-setuptools
 srt>=3.0.0
 tqdm
 typing_extensions
-webrtcvad;platform_system!='Windows'
-webrtcvad-wheels;platform_system=='Windows'
+webrtcvad-wheels


### PR DESCRIPTION
## Summary
- use `webrtcvad-wheels` on all platforms so the VAD import no longer depends on `webrtcvad`'s `pkg_resources` import
- remove `setuptools` from runtime requirements
- document the dependency change in the changelog

Fixes #229.

## Validation
- Not run locally