### PR TITLE
Upgrade auditok 0.1.5 → ≥ 0.5.2: modern API, MIT license, auto thresholding, WebRTC smoothing

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,9 +235,11 @@ If the sync fails, the following recourses are available:
   for the full story.
 - Try `--vad=auditok` since [auditok](https://github.com/amsehili/auditok) can
   sometimes work better in the case of low-quality audio than WebRTC's VAD.
-  Auditok does not specifically detect voice, but instead detects all audio;
-  this property can yield suboptimal syncing behavior when a proper VAD can
-  work well, but can be effective in some cases.
+  auditok can use energy (detect all audio; the threshold is found
+  automatically with otsu, `auditok:pXX` uses the XXth percentile instead
+  with XX in 1-99, `auditok:50` is the historical fixed threshold) or a
+  speech model (`auditok:webrtc[:N]`, N = aggressiveness 0-3: targets speech
+  only, but expect false positives).
 - Try `--vad=fused`, which combines WebRTC with the neural
   [silero](https://github.com/snakers4/silero-vad) VAD and can be more robust on
   noisy audio. The strategy can be tuned: `--vad=fused:intersection`

--- a/ffsubsync/constants.py
+++ b/ffsubsync/constants.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import re
 from typing import List, Optional, Tuple
 
 
@@ -55,6 +56,29 @@ VAD_CHOICES: Tuple[str, ...] = (
     "fused:intersection",
     "fused:union",
 )
+
+# The auditok detector additionally accepts a parameter after a colon (also
+# with a "subs_then_" prefix): a number is a fixed energy threshold in dB
+# ("auditok:50" reproduces the historical behavior), "auto"/"otsu" estimate
+# the threshold from the audio itself (bare "auditok" is an alias for
+# "auditok:auto"), "pXX" places it at the XXth percentile of window energies,
+# and "webrtc[:N]" runs auditok's event segmentation over WebRTC VAD frame
+# decisions (N = aggressiveness, 0-3). These parameterized forms cannot be
+# enumerated in VAD_CHOICES, hence the regex + helper used by validate_args.
+_AUDITOK_SPEC_RE = re.compile(
+    r"^(auto|otsu|percentile|p[1-9][0-9]?|webrtc(:[0-3])?|[0-9]+(\.[0-9]+)?)$"
+)
+
+
+def is_valid_vad(vad: str) -> bool:
+    """Return True if *vad* is a valid --vad value, including the
+    parameterized ``auditok:<spec>`` forms."""
+    if vad in VAD_CHOICES:
+        return True
+    base = vad[len("subs_then_") :] if vad.startswith("subs_then_") else vad
+    if base.startswith("auditok:"):
+        return _AUDITOK_SPEC_RE.match(base[len("auditok:") :]) is not None
+    return False
 
 # ffmpeg's whisper audio filter (a reference source alternative to audio VAD;
 # see WhisperSpeechTransformer). "auto" lets whisper detect the language; the

--- a/ffsubsync/ffsubsync.py
+++ b/ffsubsync/ffsubsync.py
@@ -32,6 +32,7 @@ from ffsubsync.constants import (
     DEFAULT_MAX_FRAMERATE_DEVIATION,
     VAD_CHOICES,
     is_remote_url,
+    is_valid_vad,
 )
 from ffsubsync.ffmpeg_utils import ffmpeg_bin_path
 from ffsubsync.sklearn_shim import Pipeline, TransformerMixin
@@ -569,9 +570,11 @@ def validate_args(args: argparse.Namespace) -> None:
     # --vad no longer uses argparse `choices` (in whisper mode it carries a model
     # path), so enforce the named-detector choices here when not in whisper mode.
     if getattr(args, "whisper_weights", None) is None and args.vad is not None:
-        if args.vad not in VAD_CHOICES:
+        if not is_valid_vad(args.vad):
             raise ValueError(
-                "invalid --vad {!r}; choose one of: {}".format(
+                "invalid --vad {!r}; choose one of: {} (auditok also accepts "
+                "a parameter, e.g. auditok:75, auditok:p20 or "
+                "auditok:webrtc:2 -- see --help)".format(
                     args.vad, ", ".join(VAD_CHOICES)
                 )
             )
@@ -1097,9 +1100,13 @@ def add_cli_only_args(parser: argparse.ArgumentParser) -> None:
         help="Which voice activity detector to use for speech extraction "
         "(if using video / audio as a reference, default={default}). Choices: "
         "{choices}. The `fused` options combine webrtc and silero and require the "
-        "optional silero dependency (torch). With --whisper-weights this instead "
-        "takes a path to a ggml VAD model for whisper's optional audio "
-        "fragmentation.".format(
+        "optional silero dependency (torch). `auditok` can use energy (detect all "
+        "audio; the threshold is found automatically with otsu, `auditok:pXX` "
+        "uses the XXth percentile instead with XX in 1-99, `auditok:50` is the "
+        "historical fixed threshold) or a speech model (`auditok:webrtc[:N]`, "
+        "N = aggressiveness 0-3: targets speech only, but expect false "
+        "positives). With --whisper-weights this instead takes a path to a ggml "
+        "VAD model for whisper's optional audio fragmentation.".format(
             default=DEFAULT_VAD, choices=", ".join(VAD_CHOICES)
         ),
     )

--- a/ffsubsync/speech_transformers.py
+++ b/ffsubsync/speech_transformers.py
@@ -101,56 +101,88 @@ def make_subtitle_speech_pipeline(
         return subpipe_maker(scale_factor)
 
 
+def _parse_auditok_spec(vad: str) -> str:
+    """Extract the parameter from an ``auditok[:spec]`` vad name (with or
+    without a ``subs_then_`` prefix). Bare ``auditok`` means ``auto``."""
+    base = vad.split("subs_then_")[-1]
+    return base.split(":", 1)[1] if ":" in base else "auto"
+
+
 def _make_auditok_detector(
-    sample_rate: int, frame_rate: int, non_speech_label: float
+    sample_rate: int,
+    frame_rate: int,
+    non_speech_label: float,
+    vad_spec: str = "auto",
 ) -> Callable[[bytes], np.ndarray]:
     try:
-        from auditok import (
-            BufferAudioSource,
-            ADSFactory,
-            AudioEnergyValidator,
-            StreamTokenizer,
-        )
+        import auditok
     except ImportError as e:
         logger.error(
-            """Error: auditok not installed!
-        Consider installing it with `pip install auditok`. Note that auditok
-        is GPLv3 licensed, which means that successfully importing it at
-        runtime creates a derivative work that is GPLv3 licensed. For personal
-        use this is fine, but note that any commercial use that relies on
-        auditok must be open source as per the GPLv3!*
-        *Not legal advice. Consult with a lawyer.
-        """
+            "Error: auditok not installed!\n"
+            "        Consider installing it with `pip install auditok` "
+            "(MIT-licensed since v0.2)."
         )
         raise e
+    if vad_spec.startswith("webrtc"):
+        try:
+            import webrtcvad  # noqa: F401
+        except ImportError as e:
+            logger.error(
+                "Error: the auditok:webrtc detector requires the webrtcvad "
+                "package (`pip install webrtcvad-wheels`)."
+            )
+            raise e
+    # A numeric spec is a fixed energy threshold in dB on auditok's scale
+    # (the historical hard-coded value was 50); anything else ("otsu",
+    # "pXX", "webrtc[:N]") is an auditok validator spec. "auto" is otsu,
+    # auditok's default estimation method; estimation runs per chunk
+    # (~100 s), so the threshold adapts across the reference.
+    if vad_spec == "auto":
+        vad_spec = "otsu"
+    try:
+        threshold_kwargs = {"energy_threshold": float(vad_spec)}
+    except ValueError:
+        threshold_kwargs = {"validator": vad_spec}
+    # threshold estimation degenerates on silent chunks (see the guard in
+    # _detect); fixed thresholds and the webrtc backend need no guard
+    estimates_threshold = "validator" in threshold_kwargs and not vad_spec.startswith(
+        "webrtc"
+    )
     bytes_per_frame = 2
     frames_per_window = frame_rate // sample_rate
-    validator = AudioEnergyValidator(sample_width=bytes_per_frame, energy_threshold=50)
-    tokenizer = StreamTokenizer(
-        validator=validator,
-        min_length=0.2 * sample_rate,
-        max_length=int(5 * sample_rate),
-        max_continuous_silence=0.25 * sample_rate,
-    )
 
-    def _detect(asegment: bytes) -> np.ndarray:
-        asource = BufferAudioSource(
-            data_buffer=asegment,
-            sampling_rate=frame_rate,
-            sample_width=bytes_per_frame,
-            channels=1,
-        )
-        ads = ADSFactory.ads(audio_source=asource, block_dur=1.0 / sample_rate)
-        ads.open()
-        tokens = tokenizer.tokenize(ads)
+    def _detect(asegment) -> np.ndarray:
+        if isinstance(asegment, np.ndarray):
+            asegment = asegment.tobytes()
         length = (
             len(asegment) // bytes_per_frame + frames_per_window - 1
         ) // frames_per_window
-        media_bstring = np.zeros(length + 1)
-        for token in tokens:
-            media_bstring[token[1]] = 1.0
-            media_bstring[token[2] + 1] = non_speech_label - 1.0
-        return np.clip(np.cumsum(media_bstring)[:-1], 0.0, 1.0)
+        media_bstring = np.full(length, non_speech_label)
+        # auditok >= 0.5.1 yields no events when estimating on digitally
+        # silent input, but a *near*-silent chunk -- e.g. a dithered black
+        # leader or credits -- still has no usable energy distribution, and
+        # an estimated threshold can mark the whole chunk as speech. 25 dB
+        # on auditok's scale (peak ~ -65 dBFS) is far below any speech.
+        if estimates_threshold:
+            peak = np.abs(np.frombuffer(asegment, np.int16)).max(initial=1)
+            if 20 * np.log10(peak) < 25.0:
+                return media_bstring
+        events = auditok.split(
+            asegment,
+            sampling_rate=frame_rate,
+            sample_width=bytes_per_frame,
+            channels=1,
+            analysis_window=1.0 / sample_rate,
+            min_dur=0.2,
+            max_dur=5,
+            max_silence=0.25,
+            **threshold_kwargs,
+        )
+        for event in events:
+            start = int(event.start * sample_rate)
+            end = min(int(round(event.end * sample_rate)), length)
+            media_bstring[start:end] = 1.0
+        return media_bstring
 
     return _detect
 
@@ -672,12 +704,17 @@ class VideoSpeechTransformer(TransformerMixin):
                 self._non_speech_label,
                 fusion_strategy,
             )
+        elif "auditok" in self.vad:
+            # NB: checked before webrtc -- "auditok:webrtc:N" selects auditok's
+            # event segmentation over webrtc frame decisions, not plain webrtc
+            detector = _make_auditok_detector(
+                self.sample_rate,
+                self.frame_rate,
+                self._non_speech_label,
+                vad_spec=_parse_auditok_spec(self.vad),
+            )
         elif "webrtc" in self.vad:
             detector = _make_webrtcvad_detector(
-                self.sample_rate, self.frame_rate, self._non_speech_label
-            )
-        elif "auditok" in self.vad:
-            detector = _make_auditok_detector(
                 self.sample_rate, self.frame_rate, self._non_speech_label
             )
         elif "silero" in self.vad:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,10 @@
-auditok==0.1.5
+auditok>=0.5.2
 chardet;python_version>='3.7'
 charset_normalizer
 faust-cchardet
 ffmpeg-python
 numpy>=1.12.0
-pysubs2;python_version<'3.7'
-pysubs2>=1.2.0;python_version>='3.7'
+pysubs2>=1.2.0
 rich
 srt>=3.0.0
 tqdm

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     packages=find_packages(exclude=['docs']),
     include_package_data=True,
     install_requires=requirements,
+    python_requires='>=3.8',
     extras_require={
         # Optional dependency for the silero / fused VAD backends.
         'torch': ['torch'],
@@ -51,8 +52,6 @@ setup(
         'Intended Audience :: End Users/Desktop',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/web/src/ffsubsync_bridge.py
+++ b/web/src/ffsubsync_bridge.py
@@ -24,6 +24,7 @@ from ffsubsync.ffsubsync import make_parser, run
 from ffsubsync.speech_transformers import (
     _make_auditok_detector,
     _make_webrtcvad_detector,
+    _parse_auditok_spec,
 )
 
 _WORK_DIR = "/work"
@@ -155,13 +156,23 @@ def _pcm_to_speech_signal(pcm: bytes, frame_rate: int, vad: str,
     chunk to the same detector, then concatenate. ``frame_rate`` is the PCM sample
     rate; for webrtcvad it must be one of 8000/16000/32000/48000 Hz.
     """
-    maker = _DETECTOR_MAKERS.get(vad)
-    if maker is None:
-        raise ValueError(
-            "unsupported browser vad %r; expected one of %s"
-            % (vad, ", ".join(sorted(_DETECTOR_MAKERS)))
+    if vad.startswith("auditok"):
+        # supports the parameterized forms too ("auditok:75", "auditok:pXX",
+        # "auditok:webrtc[:N]"); bare "auditok" auto-estimates the threshold
+        detector = _make_auditok_detector(
+            SAMPLE_RATE,
+            frame_rate,
+            non_speech_label,
+            vad_spec=_parse_auditok_spec(vad),
         )
-    detector = maker(SAMPLE_RATE, frame_rate, non_speech_label)
+    else:
+        maker = _DETECTOR_MAKERS.get(vad)
+        if maker is None:
+            raise ValueError(
+                "unsupported browser vad %r; expected one of %s"
+                % (vad, ", ".join(sorted(_DETECTOR_MAKERS)))
+            )
+        detector = maker(SAMPLE_RATE, frame_rate, non_speech_label)
 
     bytes_per_frame = 2
     frames_per_window = bytes_per_frame * frame_rate // SAMPLE_RATE


### PR DESCRIPTION
## Overview

`ffsubsync` currently pins `auditok==0.1.5`, a release from 2016. This PR upgrades to `auditok>=0.5.2` and rewrites the `--vad=auditok` detector on auditok's modern `split()` API. Three concrete wins:

* **MIT license.** auditok has been MIT-licensed since v0.2, so the old runtime GPLv3 warning is removed.
* **Automatic energy thresholding.** The detector estimates its threshold per ~100 s chunk (Otsu by default) instead of the hard-coded 50 dB, adapting across a reference with changing loudness.
* **`auditok:webrtc` hybrid mode.** WebRTC's frame decisions are shaped by auditok's event tokenizer into cleaner speech regions, using the `webrtcvad-wheels` dependency you already ship.

**Heads-up on minimum Python.** Modern auditok requires Python **≥ 3.8**, and there is no auditok release that has these features *and* supports 3.6/3.7—so this PR raises `ffsubsync`'s floor to 3.8 (it previously advertised 3.6+). If you'd rather keep 3.6/3.7 installable, there's a clean alternative that makes auditok an optional extra instead; see **Minimum Python version** below.

Before deciding, I'd genuinely encourage running the new `--vad=auditok` (auto) and `--vad=auditok:webrtc` against a noisy or far-field reference: the adaptive threshold should behave noticeably better than the old fixed 50 dB, and that behavior is really the point of the upgrade.

## Why a plain version bump isn't possible

The old detector used auditok's `ADSFactory` API, which was removed in auditok 0.3.0. The detector is therefore rewritten on the current `auditok.split()` interface. The segmentation parameters (min duration 0.2 s, max 5 s, max in-event silence 0.25 s, 10 ms analysis window) are carried over, so behavior is preserved where the mode is unchanged.

## Remove the obsolete GPL warning

The old code warned that importing auditok creates a GPLv3 derivative work. That is no longer accurate—auditok has been MIT-licensed since v0.2—so the warning is removed, clearing a licensing concern that discouraged use of this backend.

## Automatic energy thresholding

The old detector used a fixed `energy_threshold=50` for all audio. It now estimates the threshold automatically with **Otsu's method**, recomputed per ~100 s chunk so it adapts across a reference with changing loudness (e.g. quiet dialogue followed by loud action).

* `--vad=auditok` — automatic threshold via Otsu (the new default).
* `--vad=auditok:pXX` — threshold at the XXth percentile of the window-energy distribution (`XX` in 1–99); useful for sparse speech.
* `--vad=auditok:50` — a fixed threshold in dB (any number works); `50` reproduces the previous fixed-threshold behavior.

On the estimation modes, a chunk whose peak level is below ~25 dB on auditok's scale—far below any speech—is treated as non-speech, so a degenerate estimate on a near-silent chunk (a black leader or credits) can't be flagged as speech.

## auditok + WebRTC hybrid mode

```text
--vad=auditok:webrtc[:N]
```

where `N` is the WebRTC aggressiveness (`0–3`). Instead of using WebRTC's raw frame output directly, this feeds WebRTC VAD's per-frame decisions into auditok's event tokenizer. `webrtcvad-wheels` is already an `ffsubsync` dependency, so no new dependency is added.

Same underlying WebRTC classifier as `--vad=webrtc`, but its 10 ms frame decisions are shaped into cleaner regions by:

* tolerating brief silences within an utterance (`max_silence`);
* rejecting very short speech bursts (`min_dur`);
* emitting contiguous speech events instead of raw per-frame decisions.

In practice this often does better on noisy or far-field references.

## Minimum Python version

Modern auditok (≥ 0.4) declares `requires_python >= 3.8`, and the auto-threshold and webrtc features exist only in ≥ 0.5. `ffsubsync` had no `python_requires` and advertised 3.6–3.14 via classifiers. Because auditok is a hard dependency, `auditok>=0.5.2` would make `ffsubsync` uninstallable on 3.6/3.7.

**This PR raises the minimum to Python 3.8**—it adds `python_requires='>=3.8'`, drops the 3.6/3.7 classifiers, and removes the now-moot `python_version<'3.7'` markers in `requirements.txt`. Python 3.6 (EOL Dec 2021) and 3.7 (EOL Jun 2023) are well past end-of-life, and this gives everyone the full auditok backend with the least machinery.

**Alternative, if you'd rather keep 3.6/3.7 installable:** make auditok an optional extra—move `auditok>=0.5.2; python_version>='3.8'` into `extras_require` (`pip install ffsubsync[auditok]`), mirroring how `torch`/silero is already optional. `ffsubsync` then stays fully usable on 3.6/3.7 via webrtc/silero/subs; only the auditok backend is absent there—and there is no 3.6/3.7-compatible auditok with these features anyway. auditok isn't the default VAD, so out-of-the-box behavior is unchanged. Happy to switch to this if you prefer.

## Additional changes

* Fixed the `--vad` dispatch order so `auditok` is matched before `webrtc`, preventing `auditok:webrtc[:N]` from being captured by the `webrtc` branch.
* Added `--vad` validation for the parameterized `auditok:<spec>` forms, with a clear error message.
* Updated `--help` and the README to document the new syntax.
* Extended the web bridge to accept the parameterized VAD specs.

## Compatibility

The only change to existing behavior is that `--vad=auditok` now estimates the threshold automatically instead of using the historical fixed value of `50`. The previous behavior is available as `--vad=auditok:50`. All other VAD modes are unchanged (aside from the minimum-Python change above).

## Testing

`pytest tests/` — **203 passed, 1 skipped** (the skip is the integration test, which runs only with `INTEGRATION=1` and the `test-data` submodule). Verified against the published `auditok==0.5.2`.

The rewritten detector was additionally smoke-tested end to end across automatic (Otsu), percentile (`pXX`), and fixed thresholds and `auditok:webrtc[:N]`, including digitally silent and dither-only inputs (which correctly yield no speech on the energy modes).
